### PR TITLE
Support explicitly set worker hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ return [
             \zhuravljov\yii\queue\monitor\Env::class => [
                 'cache' => 'cache',
                 'db' => 'db',
+                'host' => gethostname(),
                 'pushTableName'   => '{{%queue_push}}',
                 'execTableName'   => '{{%queue_exec}}',
                 'workerTableName' => '{{%queue_worker}}',

--- a/src/Env.php
+++ b/src/Env.php
@@ -44,6 +44,10 @@ class Env extends BaseObject
      * @var int
      */
     public $workerPingInterval = 15;
+    /**
+     * @var string
+     */
+    public $host = null;
 
     /**
      * @return static
@@ -76,6 +80,11 @@ class Env extends BaseObject
      */
     public function getHost()
     {
+        // Allow the host name to be explicitly set during configuration
+        if ( $this->host !== null ) {
+            return $this->host;
+        }
+
         if ($this->db->driverName === 'mysql') {
             $host = $this->db
                 ->createCommand('SELECT `HOST` FROM `information_schema`.`PROCESSLIST` WHERE `ID` = CONNECTION_ID()')


### PR DESCRIPTION
This is particularly useful when you need to distinguish between multiple workers running in different containers on the same machine.